### PR TITLE
QoL/documentation upgrades and some typo fixes

### DIFF
--- a/EngineeringNotation.py
+++ b/EngineeringNotation.py
@@ -92,14 +92,14 @@ def si_form(number: float, unit: str = '', round_to_decimal_places: int = 2) -> 
         number (float): The number to format.
         unit (str): The unit to append to the formatted number. Default is an empty string.
         round_to_decimal_places (int): The number of decimal places to round the formatted number to. Default is 2.
+        if 0 is after the decimal, it is now omitted
         
-    
     Returns:
         str: The formatted number with SI prefixes and the provided unit.
     """
     exponent = _get_engineering_exponent(number)
     prefix = _si_prefixes.get(exponent)
-    mantissa = str(format(round(number / 10 ** exponent, round_to_decimal_places), f'.{round_to_decimal_places}f')) # part after decimal place
+    mantissa = str(round(number / 10 ** exponent, round_to_decimal_places)).rstrip('0').rstrip('.')
     outstr = f'{mantissa} {prefix}{unit}' if prefix is not None else f'{mantissa} {unit}'
     return outstr.rstrip()
 
@@ -111,13 +111,13 @@ def engineering_form(number: float, unit: str = '', round_to_decimal_places: int
         number (float): The number to format.
         unit (str): The unit to append to the formatted number. Default is an empty string.
         round_to_decimal_places (int): The number of decimal places to round the formatted number to. Default is 2.
+        if 0 is after the decimal, it is now omitted
 
-    
     Returns:
         str: The formatted number in engineering notation with the provided unit.
     """
     exponent = _get_engineering_exponent(number)
-    mantissa = str(format(round(number / 10 ** exponent, round_to_decimal_places), f'.{round_to_decimal_places}f')) # part after decimal place
+    mantissa = str(round(number / 10 ** exponent, round_to_decimal_places)).rstrip('0').rstrip('.')
     return f'{mantissa}{_get_exp_str(exponent)} {unit}' if unit != '' else f'{mantissa}{_get_exp_str(exponent)}'
 
 # alias functions

--- a/EngineeringNotation.py
+++ b/EngineeringNotation.py
@@ -92,14 +92,13 @@ def si_form(number: float, unit: str = '', round_to_decimal_places: int = 2) -> 
         number (float): The number to format.
         unit (str): The unit to append to the formatted number. Default is an empty string.
         round_to_decimal_places (int): The number of decimal places to round the formatted number to. Default is 2.
-        if 0 is after the decimal, it is now omitted
         
     Returns:
         str: The formatted number with SI prefixes and the provided unit.
     """
     exponent = _get_engineering_exponent(number)
     prefix = _si_prefixes.get(exponent)
-    mantissa = str(round(number / 10 ** exponent, round_to_decimal_places)).rstrip('0').rstrip('.')
+    mantissa = str(format(round(number / 10 ** exponent, round_to_decimal_places), f'.{round_to_decimal_places}f')) # part after decimal place
     outstr = f'{mantissa} {prefix}{unit}' if prefix is not None else f'{mantissa} {unit}'
     return outstr.rstrip()
 
@@ -111,13 +110,12 @@ def engineering_form(number: float, unit: str = '', round_to_decimal_places: int
         number (float): The number to format.
         unit (str): The unit to append to the formatted number. Default is an empty string.
         round_to_decimal_places (int): The number of decimal places to round the formatted number to. Default is 2.
-        if 0 is after the decimal, it is now omitted
 
     Returns:
         str: The formatted number in engineering notation with the provided unit.
     """
     exponent = _get_engineering_exponent(number)
-    mantissa = str(round(number / 10 ** exponent, round_to_decimal_places)).rstrip('0').rstrip('.')
+    mantissa = str(format(round(number / 10 ** exponent, round_to_decimal_places), f'.{round_to_decimal_places}f')) # part after decimal place
     return f'{mantissa}{_get_exp_str(exponent)} {unit}' if unit != '' else f'{mantissa}{_get_exp_str(exponent)}'
 
 # alias functions

--- a/EngineeringNotation.py
+++ b/EngineeringNotation.py
@@ -1,6 +1,6 @@
-import math
+from math import log10 as mathlog10
 
-__version__ = '1.1.0'
+__version__ = '1.2.0'
 
 _si_prefixes = {
     -60: 'yy', # *10^-60
@@ -24,7 +24,7 @@ _si_prefixes = {
     -6: 'μ', # *10^-6
     -3: 'm', # *10^-3
     0: None, # *10^0
-    3: 'K', # *10^3
+    3: 'k', # *10^3
     6: 'M', # *10^6
     9: 'G', # *10^9
     12: 'T', # *10^12
@@ -46,7 +46,7 @@ _si_prefixes = {
     60: 'QQ', # *10^60
 }
 
-def _get_engineering_exponent(number):
+def _get_engineering_exponent(number:float) -> int:
     """
     Calculate the engineering exponent of a given number.
     
@@ -58,12 +58,31 @@ def _get_engineering_exponent(number):
     """
     if number == 0:
         return 0
-    exponent = int(math.log10(abs(number)))
+    exponent = int(mathlog10(abs(number)))
     while exponent % 3 != 0:
         exponent -= 1
     return exponent
 
-def si_form(number: float, unit: str = '', round_to_decimal_places: int = 2):
+def _get_exp_str(exponent:int) -> str:
+    """
+    Handle printing positive, negative, and zero exponents
+
+    Parameters:
+        exponent (int): the exponent to be formatted for engineering notation
+
+    Returns:
+        str: formatted exponent, e.g. E+3 or E-2 or ''
+    """
+    signstr = ''
+    if exponent > 0:
+        signstr = f'E+{exponent}'
+    elif exponent < 0:
+        signstr = f'E{exponent}'
+    else:
+        signstr = ''
+    return signstr
+
+def si_form(number: float, unit: str = '', round_to_decimal_places: int = 2) -> str:
     """
     Format a number using SI prefixes.
     
@@ -80,7 +99,7 @@ def si_form(number: float, unit: str = '', round_to_decimal_places: int = 2):
     mantissa = round(number / 10 ** exponent, round_to_decimal_places)
     return f'{mantissa} {prefix}{unit}' if prefix is not None else f'{mantissa} {unit}'
 
-def engieering_form(number: float, unit: str = '', round_to_decimal_places: int = 2):
+def engineering_form(number: float, unit: str = '', round_to_decimal_places: int = 2) -> str:
     """
     Format a number using engineering notation.
     
@@ -94,14 +113,29 @@ def engieering_form(number: float, unit: str = '', round_to_decimal_places: int 
     """
     exponent = _get_engineering_exponent(number)
     mantissa = round(number / 10 ** exponent, round_to_decimal_places)
-    return f'{mantissa}E{exponent} {unit}'
+    return f'{mantissa}{_get_exp_str(exponent)} {unit}'
+
+# alias functions
+def sif(num:float, uni:str = '', prec:int = 2) -> str:
+    """
+    alias of si_form()
+    """
+    return si_form(num,unit=uni,round_to_decimal_places=prec)
+
+def engf(num:float, uni:str = '', prec:int = 2) -> str:
+    """
+    alias of engineering_form()
+    """
+    return engineering_form(num, unit=uni, round_to_decimal_places=prec)
 
 def _test():
     import random
     value = 15.504E4
     print(f'{value = }')
     print(f'{si_form(value, "V") = }')
-    print(f'{engieering_form(value, "V") = }')
+    print(f'{engineering_form(value, "V") = }')
+    print(f'{sif(value, "V") = }')
+    print(f'{engf(value, "V") = }')
 
 if __name__ == '__main__':
     try:

--- a/EngineeringNotation.py
+++ b/EngineeringNotation.py
@@ -68,10 +68,10 @@ def _get_engineering_exponent(number:float) -> int:
 def _get_exp_str(exponent:int) -> str:
     """
     Handle printing positive, negative, and zero exponents
-
+    
     Parameters:
         exponent (int): the exponent to be formatted for engineering notation
-
+    
     Returns:
         str: formatted exponent, e.g. E+3 or E-2 or ''
     """
@@ -93,7 +93,6 @@ def si_form(number: float, unit: str = '', round_to_decimal_places: int = 2) -> 
         unit (str): The unit to append to the formatted number. Default is an empty string.
         round_to_decimal_places (int): The number of decimal places to round the formatted number to. Default is 2.
         
-    
     Returns:
         str: The formatted number with SI prefixes and the provided unit.
     """
@@ -112,7 +111,6 @@ def engineering_form(number: float, unit: str = '', round_to_decimal_places: int
         unit (str): The unit to append to the formatted number. Default is an empty string.
         round_to_decimal_places (int): The number of decimal places to round the formatted number to. Default is 2.
 
-    
     Returns:
         str: The formatted number in engineering notation with the provided unit.
     """
@@ -135,12 +133,10 @@ def engf(num:float, uni:str = '', prec:int = 2) -> str:
 
 def _test():
     import random
-    value = 15.504
-    print(f'{value = }')
-    print(f'{si_form(value) = }')
-    print(f'{engineering_form(value) = }')
-    print(f'{sif(value, "V") = }')
-    print(f'{engf(value, "V") = }')
+    value = 15050.504
+    print(f'Value:     {value}')
+    print(f'SI Form:   {si_form(value, 'V')}')
+    print(f'Eng. Form: {engineering_form(value, 'V', 3)}')
 
 if __name__ == '__main__':
     try:

--- a/EngineeringNotation.py
+++ b/EngineeringNotation.py
@@ -92,14 +92,14 @@ def si_form(number: float, unit: str = '', round_to_decimal_places: int = 2) -> 
         number (float): The number to format.
         unit (str): The unit to append to the formatted number. Default is an empty string.
         round_to_decimal_places (int): The number of decimal places to round the formatted number to. Default is 2.
-        if 0 is after the decimal, it is now omitted
         
+    
     Returns:
         str: The formatted number with SI prefixes and the provided unit.
     """
     exponent = _get_engineering_exponent(number)
     prefix = _si_prefixes.get(exponent)
-    mantissa = str(round(number / 10 ** exponent, round_to_decimal_places)).rstrip('0').rstrip('.')
+    mantissa = str(format(round(number / 10 ** exponent, round_to_decimal_places), f'.{round_to_decimal_places}f')) # part after decimal place
     outstr = f'{mantissa} {prefix}{unit}' if prefix is not None else f'{mantissa} {unit}'
     return outstr.rstrip()
 
@@ -111,13 +111,13 @@ def engineering_form(number: float, unit: str = '', round_to_decimal_places: int
         number (float): The number to format.
         unit (str): The unit to append to the formatted number. Default is an empty string.
         round_to_decimal_places (int): The number of decimal places to round the formatted number to. Default is 2.
-        if 0 is after the decimal, it is now omitted
 
+    
     Returns:
         str: The formatted number in engineering notation with the provided unit.
     """
     exponent = _get_engineering_exponent(number)
-    mantissa = str(round(number / 10 ** exponent, round_to_decimal_places)).rstrip('0').rstrip('.')
+    mantissa = str(format(round(number / 10 ** exponent, round_to_decimal_places), f'.{round_to_decimal_places}f')) # part after decimal place
     return f'{mantissa}{_get_exp_str(exponent)} {unit}' if unit != '' else f'{mantissa}{_get_exp_str(exponent)}'
 
 # alias functions

--- a/README.md
+++ b/README.md
@@ -1,21 +1,26 @@
 # Engineering Notation
 
-This Python class provides functionality to convert numeric values into engineering notation. Engineering notation is a way of representing numbers in scientific notation but the exponent is a power of 3, allowing numbers to be directly read as SI units.
+This Python module provides functionality to convert numeric values into engineering notation. Engineering notation is a way of representing numbers in scientific notation but the exponent is a power of 3, allowing numbers to be directly read as SI units.
 
 ## Example usage
 
 ```py
-from EngineeringNotation import EngineeringNotation
+from EngineeringNotation import *
 
-# Example usage
 value = 12345678.9
-eng_notation = EngineeringNotation(value)
 
 # Get the value in standard SI form (with metric prefix)
-si_form = eng_notation.get_si_form()
-print(si_form) # Prints: 12.35 M as in Mega
+si_value = si_form(value)
+# sif(value) is an alias of si_form(value)
+print(si_value) # Prints: 12.35 M as in Mega
 
 # Get the value in engineering form (with exponent)
-eng_form = eng_notation.get_engieering_form()
-print(eng_form) # Prints: 12.35E6 as in 12.35*10^6
+eng_value = engineering_form(value)
+# engf(value) is an alias of engineering_form(value)
+print(eng_value) # Prints: 12.35E+6 as in 12.35*10^6
+```
+## Formatting Units and Significant Digits
+Both formatters are capable of incorporating units and rounding to a select number of digits after the decimal point. For example:
+```
+print(si_value(value, 'V', 3)) # Prints: 12.346 MV
 ```


### PR DESCRIPTION
This pull request addresses #1 with some minor changes:

- fix function name typo and wrong capitalization on the kilo prefix
- amend the `engineering_form` output to gracefully handle +/-/0 exponents
- add alias functions for more readable inline number formatting
- update the readme to reflect current functionality of the module